### PR TITLE
♻️ Refactor SEAL-ISAC Query

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pycti==6.3.11
 python-dotenv==1.0.1
 requests==2.32.3
-urllib3==2.2.3
+urllib3==2.3.0


### PR DESCRIPTION
### 🕓 Changelog

This PR refactors the SEAL-ISAC query to implement the new logic implemented [here](https://github.com/security-alliance/seal-isac-sdk.js/blob/c349394eb2d82058e90ea634f5a3dd0647fbf6c5/src/web-content/client.ts#L149-L170):

```js
public async getWebContentStatus(content: WebContent): Promise<"blocked" | "trusted" | "unknown"> {
    const [observable, indicator] = await Promise.all([
        this.client.getStixCyberObservable(generateObservableIdForWebContent(content)),
        this.client.getIndicator(generateIndicatorId({ pattern: generatePatternForWebContent(content) })),
    ]);

    if (observable !== null) {
        if (this.findLabel(observable, TRUSTED_WEB_CONTENT_LABEL) !== undefined) return "trusted";

        if (this.findLabel(observable, ALLOWLISTED_DOMAIN_LABEL) !== undefined) return "trusted";

        if (this.findLabel(observable, BLOCKLISTED_DOMAIN_LABEL) !== undefined) return "blocked";
    }

    if (indicator !== null) {
        if (indicator.revoked) return "unknown";

        return "blocked";
    }

    return "unknown";
}
```

Please note that `BLOCKLISTED_DOMAIN_LABEL` and `ALLOWLISTED_DOMAIN_LABEL` are deprecated (see [here](https://github.com/security-alliance/seal-isac-sdk.js/blob/c349394eb2d82058e90ea634f5a3dd0647fbf6c5/src/web-content/types.ts#L3-L10)), and backward compatibility is not supported in this repository.