### PR TITLE
🔁 Bump `pycti` to Version `7.260309.0.1`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pycti==6.8.9
-python-dotenv==1.2.1
+pycti==7.260309.0.1
+python-dotenv==1.2.2
 requests==2.32.5
 urllib3==2.6.3

--- a/scripts/blocklist.py
+++ b/scripts/blocklist.py
@@ -178,7 +178,7 @@ class DomainChecker:
             observable = client.stix_cyber_observable.read(filters=observable_filters)
 
             # Please note that the labels `allowlisted domain` and `blocklisted domain`
-            # have been deprecated. See: https://github.com/security-alliance/seal-isac-sdk.js/blob/c349394eb2d82058e90ea634f5a3dd0647fbf6c5/src/web-content/types.ts#L3-L10.
+            # have been deprecated. See: https://github.com/security-alliance/seal-intel-sdk/blob/3bf98ff5e38e3a2c9b557d35fdd31c8868638d52/src/web-content/types.ts#L4-L11.
             if observable:
                 labels = {label["value"] for label in observable.get("objectLabel", [])}
                 if any(

--- a/scripts/blocklist.py
+++ b/scripts/blocklist.py
@@ -15,7 +15,6 @@ from typing import List, Dict, Optional
 from dotenv import load_dotenv
 from pycti import OpenCTIApiClient
 
-
 load_dotenv()
 
 


### PR DESCRIPTION
### 🕓 Changelog

This PR updates the `pycti` dependency to the latest version [`7.260309.0.1`](https://github.com/OpenCTI-Platform/opencti/releases/tag/7.260309.0) and upgrades [`python-dotenv`] to version [`1.2.2`](https://github.com/theskumar/python-dotenv/releases/tag/v1.2.2). Please note that the `pycti` Python code has been moved to the [`client-python`](https://github.com/OpenCTI-Platform/opencti/tree/master/client-python) directory of the [OpenCTI](https://github.com/OpenCTI-Platform/opencti) repository.